### PR TITLE
Added filter for path length

### DIFF
--- a/curvature-filter-length
+++ b/curvature-filter-length
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import os
+import sys
+import codecs
+import msgpack
+import argparse
+
+parser = argparse.ArgumentParser(description='Filter out items not meeting our length levels.')
+parser.add_argument('--min', type=float, default=0, help='The minimum length level to be included in the output, e.g. 300, default 0 means no minum')
+parser.add_argument('--max', type=float, default=0, help='The maximum length level to be included in the output, e.g. 5000, default 0 means no maximum')
+args = parser.parse_args()
+
+# Set our output to default to UTF-8
+reload(sys)
+sys.setdefaultencoding('utf-8')
+sys.stderr = codecs.getwriter('utf8')(sys.stderr)
+# sys.stdout = codecs.getwriter('utf8')(sys.stdout)
+
+unpacker = msgpack.Unpacker(sys.stdin, use_list=True)
+for item in unpacker:
+    if item['length'] >= args.min and (not args.max or item['length'] <= args.max):
+        sys.stdout.write(msgpack.packb(item))


### PR DESCRIPTION
Since we added the possibility of paths consisting of only one segment, a lot of paths with very short distances have entered the data set. Here is a way to filter out very short segments, I use the `--min 1500`` to get most residential roads in cities filtered