### PR TITLE
Fixed ways with no segments being added

### DIFF
--- a/curvature/collector.py
+++ b/curvature/collector.py
@@ -533,7 +533,8 @@ class WayCollector(object):
 
 		# Special case where ways will never be split
 		if self.straight_segment_split_threshold <= 0:
-			sections.append(way)
+			if len(way['segments']) > 0:
+				sections.append(way)
 			return sections
 
 		curve_start = 0


### PR DESCRIPTION
 when using `--straight_segment_split_threshold 0`
