### PR TITLE
Added three identical example chains

### DIFF
--- a/processing_chains/callback_chain_example.py
+++ b/processing_chains/callback_chain_example.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import os
+import sys
+import codecs
+import msgpack
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'lib'))
+
+from curvature.post_processors.filter_out_ways_with_tag import FilterOutWaysWithTag
+from curvature.post_processors.add_segments import AddSegments
+from curvature.post_processors.add_segment_length_and_radius import AddSegmentLengthAndRadius
+from curvature.post_processors.add_segment_curvature import AddSegmentCurvature
+from curvature.post_processors.filter_segment_deflections import FilterSegmentDeflections
+from curvature.post_processors.split_collections_on_straight_segments import SplitCollectionsOnStraightSegments
+from curvature.post_processors.add_way_length import AddWayLength
+from curvature.post_processors.add_way_curvature import AddWayCurvature
+from curvature.post_processors.filter_collections_by_curvature import FilterCollectionsByCurvature
+from curvature.post_processors.sort_collections_by_sum import SortCollectionsBySum
+
+# Set our output to default to UTF-8
+reload(sys)
+sys.setdefaultencoding('utf-8')
+# sys.stdout = codecs.getwriter('utf8')(sys.stdout)
+sys.stderr = codecs.getwriter('utf8')(sys.stderr)
+
+class CallbackedProcessor(object):
+  def __init__(self, processor, callback):
+    self.processor = processor
+    self.callback = callback
+
+  def input(self, arg):
+    # Since processors do not have a process_item interface we are mocking it for now
+    for output in self.processor.process([arg]):
+      self.callback(output)
+
+
+# Take the following processing steps first:
+# 1. Collect the highway ways and their points into collections.
+# 2. Filter out unpaved ways and highway types we aren't interested in.
+# 3. Add segments and their lengths & radii.
+# 4. Calculate the curvature and filter curvature values for "deflections" (noisy data)
+# 5. Split our collections on long straight-aways (longer than 1.5 miles) to avoid
+#    highlighting long straight roads with infrequent curvy-sections.
+# 6. Sum the length and curvature of the sections in each way for reuse.
+# 7. Filter out collections not meeting our minimum curvature thresholds.
+# 3. Sort the items by their curvature value.
+# 3. Save the intermediate data.
+
+
+chain = [
+  FilterOutWaysWithTag('surface', ['unpaved','dirt','gravel','fine_gravel','sand','grass','ground','pebblestone','mud','clay','dirt/sand','soil']),
+  FilterOutWaysWithTag('service', ['driveway', 'parking_aisle', 'drive-through', 'parking', 'bus', 'emergency_access']),
+  AddSegments(),
+  AddSegmentLengthAndRadius(),
+  AddSegmentCurvature(),
+  FilterSegmentDeflections(),
+  SplitCollectionsOnStraightSegments(2414),
+  AddWayLength(),
+  AddWayCurvature(),
+  FilterCollectionsByCurvature(min=300),
+  SortCollectionsBySum(key='curvature', reverse=True)
+]
+
+def print_msgpack(arg):
+  sys.stdout.write(msgpack.packb(arg))
+
+prev_callback = print_msgpack
+
+for processor in reversed(chain):
+  prev_callback = CallbackedProcessor(processor, prev_callback).input
+
+for collection in msgpack.Unpacker(sys.stdin, use_list=True):
+  prev_callback(collection)
+
+

--- a/processing_chains/chain_example.py
+++ b/processing_chains/chain_example.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+import os
+import sys
+import codecs
+import msgpack
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), 'lib'))
+
+from curvature.post_processors.filter_out_ways_with_tag import FilterOutWaysWithTag
+from curvature.post_processors.add_segments import AddSegments
+from curvature.post_processors.add_segment_length_and_radius import AddSegmentLengthAndRadius
+from curvature.post_processors.add_segment_curvature import AddSegmentCurvature
+from curvature.post_processors.filter_segment_deflections import FilterSegmentDeflections
+from curvature.post_processors.split_collections_on_straight_segments import SplitCollectionsOnStraightSegments
+from curvature.post_processors.add_way_length import AddWayLength
+from curvature.post_processors.add_way_curvature import AddWayCurvature
+from curvature.post_processors.filter_collections_by_curvature import FilterCollectionsByCurvature
+from curvature.post_processors.sort_collections_by_sum import SortCollectionsBySum
+
+# Set our output to default to UTF-8
+reload(sys)
+sys.setdefaultencoding('utf-8')
+# sys.stdout = codecs.getwriter('utf8')(sys.stdout)
+sys.stderr = codecs.getwriter('utf8')(sys.stderr)
+
+# Take the following processing steps first:
+# 1. Collect the highway ways and their points into collections.
+# 2. Filter out unpaved ways and highway types we aren't interested in.
+# 3. Add segments and their lengths & radii.
+# 4. Calculate the curvature and filter curvature values for "deflections" (noisy data)
+# 5. Split our collections on long straight-aways (longer than 1.5 miles) to avoid
+#    highlighting long straight roads with infrequent curvy-sections.
+# 6. Sum the length and curvature of the sections in each way for reuse.
+# 7. Filter out collections not meeting our minimum curvature thresholds.
+# 3. Sort the items by their curvature value.
+# 3. Save the intermediate data.
+
+
+chain = [
+  msgpack.Unpacker(sys.stdin, use_list=True),
+  FilterOutWaysWithTag('surface', ['unpaved','dirt','gravel','fine_gravel','sand','grass','ground','pebblestone','mud','clay','dirt/sand','soil']),
+  FilterOutWaysWithTag('service', ['driveway', 'parking_aisle', 'drive-through', 'parking', 'bus', 'emergency_access']),
+  AddSegments(),
+  AddSegmentLengthAndRadius(),
+  AddSegmentCurvature(),
+  FilterSegmentDeflections(),
+  SplitCollectionsOnStraightSegments(2414),
+  AddWayLength(),
+  AddWayCurvature(),
+  FilterCollectionsByCurvature(min=300),
+  SortCollectionsBySum(key='curvature', reverse=True)
+]
+
+process_chain = reduce(lambda acc, processor: processor.process(acc), chain)
+
+def print_msgpack(arg):
+  sys.stdout.write(msgpack.packb(arg))
+
+for collection in process_chain:
+  print_msgpack(collection)
+
+
+

--- a/processing_chains/pp_example.sh
+++ b/processing_chains/pp_example.sh
@@ -1,11 +1,18 @@
-bin/curvature-pp filter_out_ways_with_tag --tag surface --values 'unpaved,dirt,gravel,fine_gravel,sand,grass,ground,pebblestone,mud,clay,dirt/sand,soil' \
-| bin/curvature-pp filter_out_ways_with_tag --tag service --values 'driveway,parking_aisle,drive-through,parking,bus,emergency_access' \
-| bin/curvature-pp add_segments \
-| bin/curvature-pp add_segment_length_and_radius \
-| bin/curvature-pp add_segment_curvature \
-| bin/curvature-pp filter_segment_deflections \
-| bin/curvature-pp split_collections_on_straight_segments --length 2414 \
-| bin/curvature-pp add_way_length \
-| bin/curvature-pp add_way_curvature \
-| bin/curvature-pp filter_collections_by_curvature --min 300 \
-| bin/curvature-pp sort_collections_by_sum --key curvature --direction DESC \
+# Store our the program path.
+pushd `dirname $0` > /dev/null
+my_path=`pwd -P`
+popd > /dev/null
+script_path=`dirname $my_path`
+script_path="${script_path}/bin"
+
+$script_path/curvature-pp filter_out_ways_with_tag --tag surface --values 'unpaved,dirt,gravel,fine_gravel,sand,grass,ground,pebblestone,mud,clay,dirt/sand,soil' \
+| $script_path/curvature-pp filter_out_ways_with_tag --tag service --values 'driveway,parking_aisle,drive-through,parking,bus,emergency_access' \
+| $script_path/curvature-pp add_segments \
+| $script_path/curvature-pp add_segment_length_and_radius \
+| $script_path/curvature-pp add_segment_curvature \
+| $script_path/curvature-pp filter_segment_deflections \
+| $script_path/curvature-pp split_collections_on_straight_segments --length 2414 \
+| $script_path/curvature-pp add_way_length \
+| $script_path/curvature-pp add_way_curvature \
+| $script_path/curvature-pp filter_collections_by_curvature --min 300 \
+| $script_path/curvature-pp sort_collections_by_sum --key curvature --direction DESC

--- a/processing_chains/pp_example.sh
+++ b/processing_chains/pp_example.sh
@@ -1,0 +1,11 @@
+bin/curvature-pp filter_out_ways_with_tag --tag surface --values 'unpaved,dirt,gravel,fine_gravel,sand,grass,ground,pebblestone,mud,clay,dirt/sand,soil' \
+| bin/curvature-pp filter_out_ways_with_tag --tag service --values 'driveway,parking_aisle,drive-through,parking,bus,emergency_access' \
+| bin/curvature-pp add_segments \
+| bin/curvature-pp add_segment_length_and_radius \
+| bin/curvature-pp add_segment_curvature \
+| bin/curvature-pp filter_segment_deflections \
+| bin/curvature-pp split_collections_on_straight_segments --length 2414 \
+| bin/curvature-pp add_way_length \
+| bin/curvature-pp add_way_curvature \
+| bin/curvature-pp filter_collections_by_curvature --min 300 \
+| bin/curvature-pp sort_collections_by_sum --key curvature --direction DESC \


### PR DESCRIPTION
These should be @adamfranco defaults

Since we have coupled the `iterator` logic with the actual processing of each processor the callback version calls process every time with a new list with one element

I have verified with a smaller dataset (Fiji) that the output is identical from all 3 scripts