### PR TITLE
Cleaned up collector logging

### DIFF
--- a/bin/curvature-collect
+++ b/bin/curvature-collect
@@ -49,7 +49,4 @@ def output(collection):
     sys.stdout.write(msgpack.packb(collection))
 # start parsing
 for file in args.file:
-    if args.v:
-        sys.stderr.write("\nLoading {}".format(file.name))
-
     collector.parse(file.name, output)


### PR DESCRIPTION
Here is some example output

```
$ bin/curvature-collect -v pbfs/fiji-latest.osm.pbf > /dev/null
Loading pbfs/fiji-latest.osm.pbf	7.0MB
Loading ways, each '-' is 100 ways, each row is 10,000 ways	7.0MB
----------------------------------------------------------------------------------------------------
-----------------------------------------------
Ways matched in pbfs/fiji-latest.osm.pbf	60.0MB
257775 coordinates will be loaded, each '.' is 1% complete	60.0MB
....................................................................................................
Coordinates loaded	90.0MB
14180 routes & ways have their coordinates added. Each '.' is 1% complete	90.0MB
....................................................................................................
Applying coordinates to ways complete	93.0MB
886 routes will be joined, each '.' is 1% complete	93.0MB
..............................................................................................................
Joining completed in 0.0 seconds	94.0MB
Streaming completed in 2.1	94.0MB
```