### PR TITLE
Fixed two points being so close that a floating point precision error occurred

### DIFF
--- a/curvature/geomath.py
+++ b/curvature/geomath.py
@@ -50,6 +50,8 @@ def distance_on_unit_sphere(lat1, long1, lat2, long2):
 
     cos = (math.sin(phi1)*math.sin(phi2)*math.cos(theta1 - theta2) +
            math.cos(phi1)*math.cos(phi2))
+    if cos > 1:
+        return 0
     arc = math.acos( cos )
 
     # Remember to multiply arc by the radius of the earth

--- a/test/test_geomath.py
+++ b/test/test_geomath.py
@@ -1,0 +1,8 @@
+# Add our parent folder to our path
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from curvature import geomath
+
+def test_distance_on_earth_short_distance():
+  assert geomath.distance_on_unit_sphere(47.86242430000005, 7.8065880000000005, 47.86242420000014, 7.806588099999998) == 0


### PR DESCRIPTION
This is what caused `Math domain error`

For reference `repr` is how you get python to print the full precision of a float