### PR TITLE
Add post processors to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(name='curvature',
       author='Adam Franco',
       author_email='adamfranco@gmail.com',
       url='https://www.github.com/adamfranco/curvature/',
-      packages=['curvature'],
+      packages=['curvature', 'curvature.post_processors'],
      )


### PR DESCRIPTION
This fixes the `post_processors` from being omitted when building the package which can be installed locally by running

```
python setup.py sdist
sudo pip install dist/curvature-0.1.0.tar.gz
```